### PR TITLE
Add to .net 8 to donet-tailwind target frameworks

### DIFF
--- a/Tailwind/Tailwind.csproj
+++ b/Tailwind/Tailwind.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFrameworks>net7.0</TargetFrameworks>
+		<TargetFrameworks>net7.0;net8.0</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<PublishAot>false</PublishAot>


### PR DESCRIPTION
Update dotnet tailwind to support .net 8 through csproj change.